### PR TITLE
Mac一本化対応: gaming削除・LC/LG全入れ替え・Layer5 Mac化

### DIFF
--- a/config/roBa.keymap
+++ b/config/roBa.keymap
@@ -128,9 +128,9 @@
         default {
             bindings = <
 &kp Q      &kp W         &kp E                             &kp R  &kp T                                                                          &kp Y                                    &kp U  &kp I        &kp O    &kp P
-&kp A      &kp S         &mt_exit_AML_on_tap LEFT_SHIFT D  &kp F  &kp G        &trans                &tog 3                                      &kp H                                    &kp J  &kp K        &kp L    &kp MINUS
-&kp Z      &kp X         &kp C                             &kp V  &kp B        &kp LEFT_CONTROL      &kp RIGHT_GUI                               &kp N                                    &kp M  &lt 5 COMMA  &kp DOT  &kp BACKSPACE
-&kp LSHFT  &kp LEFT_WIN  &kp LEFT_ALT                      &mo 1  &lt 5 SPACE  &lt 2 LANGUAGE_2      &mt_exit_AML_on_tap RIGHT_SHIFT LANGUAGE_1  &mt_exit_AML_on_tap RIGHT_CONTROL ENTER                               &kp RIGHT_SHIFT
+&kp A      &kp S         &mt_exit_AML_on_tap LEFT_SHIFT D  &kp F  &kp G        &trans                &trans                                      &kp H                                    &kp J  &kp K        &kp L    &kp MINUS
+&kp Z      &kp X             &kp C                             &kp V  &kp B        &kp LEFT_GUI          &kp RIGHT_CONTROL                           &kp N                                    &kp M  &lt 5 COMMA  &kp DOT  &kp BACKSPACE
+&kp LSHFT  &kp LEFT_CONTROL  &kp LEFT_ALT                      &mo 1  &lt 5 SPACE  &lt 2 LANGUAGE_2      &mt_exit_AML_on_tap RIGHT_SHIFT LANGUAGE_1  &mt_exit_AML_on_tap RIGHT_GUI ENTER                                   &kp RIGHT_SHIFT
             >;
 
             sensor-bindings = <&inc_dec_kp LS(TAB) TAB>;
@@ -138,7 +138,7 @@
 
         symbol_arrow {
             bindings = <
-&kp EXCLAMATION  &kp AT_SIGN      &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp RCTRL                                  &kp TILDE      &kp QUESTION  &kp COLON     &kp SEMI   &kp PLUS
+&kp EXCLAMATION  &kp AT_SIGN      &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp RGUI                                   &kp TILDE      &kp QUESTION  &kp COLON     &kp SEMI   &kp PLUS
 &kp LEFT_BRACE   &kp RIGHT_BRACE  &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp DOLLAR   &trans              &kp HOME  &kp AMPERSAND  &kp EQUAL     &kp UP_ARROW  &kp SQT    &kp DOUBLE_QUOTES
 &kp PIPE         &kp ASTERISK     &kp HASH              &kp GRAVE              &kp PERCENT  &kp UNDERSCORE      &kp END   &kp BSLH       &kp LEFT      &kp DOWN      &kp RIGHT  &kp FSLH
 &trans           &trans           &trans                &trans                 &trans       &trans              &trans    &trans                                                &trans
@@ -147,24 +147,22 @@
 
         number_symbol {
             bindings = <
-&kp ASTERISK  &kp N7  &kp N8  &kp N9  &kp MINUS                                &kp F10  &kp F7  &kp F8  &kp F9  &kp LC(LS(K))
+&kp ASTERISK  &kp N7  &kp N8  &kp N9  &kp MINUS                                &kp F10  &kp F7  &kp F8  &kp F9  &kp LG(LS(K))
 &kp N0        &kp N4  &kp N5  &kp N6  &kp PLUS   &trans      &trans            &kp F11  &kp F4  &kp F5  &kp F6  &trans
-&kp SLASH     &kp N1  &kp N2  &kp N3  &kp DOT    &trans      &kp LA(LS(DOWN))  &kp F12  &kp F1  &kp F2  &kp F3  &kp LC(SLASH)
+&kp SLASH     &kp N1  &kp N2  &kp N3  &kp DOT    &trans      &kp LA(LS(DOWN))  &kp F12  &kp F1  &kp F2  &kp F3  &kp LG(SLASH)
 &trans        &trans  &trans  &trans  &trans     &trans      &trans            &trans                           &trans
             >;
 
-            sensor-bindings = <&inc_dec_kp LC(PAGE_UP) LC(PAGE_DOWN)>;
+            sensor-bindings = <&inc_dec_kp LG(PAGE_UP) LG(PAGE_DOWN)>;
         };
 
-        gaming {
+        empty_3 {
             bindings = <
-&kp Q      &kp W         &kp E         &kp R           &kp T                                         &kp Y      &kp U     &kp I      &kp O       &kp P
-&kp A      &kp S         &kp D         &kp F           &kp G      &trans          &tog 3             &kp H      &mkp MB1  &mkp MB3   &mkp MB2    &kp MINUS
-&kp Z      &kp X         &kp C         &kp V           &kp B      &mo 5           &kp F3             &kp N      &kp M     &kp COMMA  &kp PERIOD  &kp BACKSPACE
-&kp LSHFT  &kp LEFT_WIN  &kp LEFT_ALT  &kp LEFT_SHIFT  &kp SPACE  &kp ESCAPE      &kp RIGHT_CONTROL  &kp ENTER                                   &kp F5
+&trans  &trans  &trans  &trans  &trans                      &trans  &trans  &trans  &trans  &trans
+&trans  &trans  &trans  &trans  &trans  &trans      &trans  &trans  &trans  &trans  &trans  &trans
+&trans  &trans  &trans  &trans  &trans  &trans      &trans  &trans  &trans  &trans  &trans  &trans
+&trans  &trans  &trans  &trans  &trans  &trans      &trans  &trans                          &trans
             >;
-
-            sensor-bindings = <&inc_dec_kp LS(TAB) TAB>;
         };
 
         mouse {
@@ -178,13 +176,13 @@
 
         scroll_fn_bluetooth {
             bindings = <
-&kp LC(LA(DELETE))  &trans          &kp LG(LS(UP_ARROW))  &trans             &trans                                &bt BT_SEL 2  &kp LG(LS(N8))        &kp LG(LS(N9))      &kp LG(LS(N0))  &bt BT_SEL 4
-&kp LEFT_CONTROL    &kp LG(LS(S))   &kp LC(PAGE_UP)       &kp LC(PAGE_DOWN)  &trans  &trans      &trans            &bt BT_SEL 1  &kp LG(LEFT_ARROW)    &kp LG(UP_ARROW)    &kp LG(RIGHT)   &bt BT_SEL 3
-&kp LEFT_SHIFT      &kp K_MUTE      &kp C_VOLUME_DOWN     &kp C_VOLUME_UP    &trans  &trans      &kp LG(LS(LEFT))  &bt BT_SEL 0  &kp LG(LS(NUMBER_6))  &kp LC(DOWN_ARROW)  &kp LG(LS(N7))  &trans
-&trans              &bt BT_CLR_ALL  &bt BT_CLR            &trans             &trans  &trans      &trans            &trans                                                                  &trans
+&kp LG(LS(N4))  &trans          &trans             &trans             &trans                          &bt BT_SEL 2  &trans              &trans              &trans          &bt BT_SEL 4
+&kp LEFT_GUI    &trans          &kp LG(LA(LEFT))  &kp LG(LA(RIGHT))  &trans  &trans      &trans  &bt BT_SEL 1  &kp LC(LEFT_ARROW)  &kp LC(UP_ARROW)    &kp LC(RIGHT)   &bt BT_SEL 3
+&kp LEFT_SHIFT  &kp K_MUTE      &kp C_VOLUME_DOWN  &kp C_VOLUME_UP   &trans  &trans      &trans  &bt BT_SEL 0  &trans              &kp LG(DOWN_ARROW)  &trans          &trans
+&trans          &bt BT_CLR_ALL  &bt BT_CLR         &trans            &trans  &trans      &trans  &trans                                                                &trans
             >;
 
-            sensor-bindings = <&inc_dec_kp LC(MINUS) LC(SEMI)>;
+            sensor-bindings = <&inc_dec_kp LG(MINUS) LG(EQUAL)>;
         };
     };
 };


### PR DESCRIPTION
- gamingレイヤーを空レイヤー(layer3)に置き換え
- defaultレイヤーのgaming toggle(&tog 3)を削除
- 全レイヤーでCtrl(LC)とCmd(LG)を入れ替え（Karabiner廃止対応）
- Layer5をMac専用に再設計
  - スクリーンショット: Cmd+Shift+4
  - Chromeタブ切り替え: Cmd+Opt+←/→
  - エンコーダー: ズームイン/アウト(Cmd+=/-)
  - Windows系ショートカット全削除