### PR TITLE
fix: タブ切り替えをCmd+Shift+[/]に変更（全アプリ対応）

### DIFF
--- a/config/roBa.keymap
+++ b/config/roBa.keymap
@@ -179,7 +179,7 @@
         scroll_fn_bluetooth {
             bindings = <
 &kp LG(LS(N4))  &trans                &trans             &trans             &trans                      &bt BT_SEL 2  &kp LG(LS(N8))          &kp LG(LS(N9))          &kp LG(LS(N0))     &bt BT_SEL 4
-&kp LEFT_GUI    &kp LG(LS(NUMBER_4))  &kp LG(LA(LEFT))   &kp LG(LA(RIGHT))  &trans  &trans      &trans  &bt BT_SEL 1  &kp LG(LS(LEFT_ARROW))  &kp LG(LS(ENTER))       &kp LG(LS(RIGHT))  &bt BT_SEL 3
+&kp LEFT_GUI    &kp LG(LS(NUMBER_4))  &kp LG(LS(LBKT))  &kp LG(LS(RBKT))  &trans  &trans      &trans  &bt BT_SEL 1  &kp LG(LS(LEFT_ARROW))  &kp LG(LS(ENTER))       &kp LG(LS(RIGHT))  &bt BT_SEL 3
 &kp LEFT_SHIFT  &kp K_MUTE            &kp C_VOLUME_DOWN  &kp C_VOLUME_UP    &trans  &trans      &trans  &bt BT_SEL 0  &kp LG(LS(N6))          &kp LG(LS(DOWN_ARROW))  &kp LG(LS(N7))     &trans
 &trans          &bt BT_CLR_ALL        &bt BT_CLR         &trans             &trans  &trans      &trans  &trans                                                                           &trans
             >;


### PR DESCRIPTION
Cmd+Opt+←/→はChrome専用のためCmd+Shift+[/]に変更。
Chrome・Terminal・Safari等すべてのMacアプリで動作する。