### PR TITLE
feat: Home Row Mods（HRM）を実装

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,4 +2,4 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@main
+    uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@v0.3-branch

--- a/build.yaml
+++ b/build.yaml
@@ -18,10 +18,10 @@
 #
 ---
 include:
- - board: xiao_ble//zmk
+ - board: seeeduino_xiao_ble
    shield: roBa_R
    snippet: studio-rpc-usb-uart
- - board: xiao_ble//zmk
+ - board: seeeduino_xiao_ble
    shield: roBa_L
- - board: xiao_ble//zmk
+ - board: seeeduino_xiao_ble
    shield: settings_reset

--- a/build.yaml
+++ b/build.yaml
@@ -18,10 +18,10 @@
 #
 ---
 include:
- - board: seeeduino_xiao_ble
+ - board: xiao_ble//zmk
    shield: roBa_R
    snippet: studio-rpc-usb-uart
- - board: seeeduino_xiao_ble
+ - board: xiao_ble//zmk
    shield: roBa_L
- - board: seeeduino_xiao_ble
+ - board: xiao_ble//zmk
    shield: settings_reset

--- a/config/roBa.keymap
+++ b/config/roBa.keymap
@@ -122,6 +122,69 @@
             flavor = "balanced";
             quick-tap-ms = <200>;
         };
+
+        // Home Row Mods（HRM）
+        // Key positions:
+        //   Row1: Q(0)  W(1)  E(2)  R(3)  T(4)  | Y(5)  U(6)  I(7)  O(8)  P(9)
+        //   Row2: A(10) S(11) D(12) F(13) G(14) m(15) | m(16) H(17) J(18) K(19) L(20) -(21)
+        //   Row3: Z(22) X(23) C(24) V(25) B(26) m(27) | m(28) N(29) M(30) ,(31) .(32) BS(33)
+        //   Row4: LS(34) LC(35) LA(36) mo1(37) spc(38) lang2(39) | lang1(40) ent(41) RS(42)
+
+        // Ctrl/Alt用（hold-while-undecided なし）
+        hml: home_row_mod_left {
+            compatible = "zmk,behavior-hold-tap";
+            label = "HML";
+            #binding-cells = <2>;
+            flavor = "balanced";
+            tapping-term-ms = <280>;
+            quick-tap-ms = <175>;
+            require-prior-idle-ms = <150>;
+            bindings = <&kp>, <&kp>;
+            hold-trigger-key-positions = <5 6 7 8 9 16 17 18 19 20 21 28 29 30 31 32 33 40 41 42>;
+            hold-trigger-on-release;
+        };
+
+        hmr: home_row_mod_right {
+            compatible = "zmk,behavior-hold-tap";
+            label = "HMR";
+            #binding-cells = <2>;
+            flavor = "balanced";
+            tapping-term-ms = <280>;
+            quick-tap-ms = <175>;
+            require-prior-idle-ms = <150>;
+            bindings = <&kp>, <&kp>;
+            hold-trigger-key-positions = <0 1 2 3 4 10 11 12 13 14 15 22 23 24 25 26 27 34 35 36 37 38 39>;
+            hold-trigger-on-release;
+        };
+
+        // Shift/Cmd用（hold-while-undecided あり → マウス操作との組み合わせに即反応）
+        hml_2: home_row_mod_left_2 {
+            compatible = "zmk,behavior-hold-tap";
+            label = "HML_2";
+            #binding-cells = <2>;
+            flavor = "balanced";
+            tapping-term-ms = <280>;
+            quick-tap-ms = <175>;
+            require-prior-idle-ms = <150>;
+            bindings = <&kp>, <&kp>;
+            hold-trigger-key-positions = <5 6 7 8 9 16 17 18 19 20 21 28 29 30 31 32 33 40 41 42>;
+            hold-trigger-on-release;
+            hold-while-undecided;
+        };
+
+        hmr_2: home_row_mod_right_2 {
+            compatible = "zmk,behavior-hold-tap";
+            label = "HMR_2";
+            #binding-cells = <2>;
+            flavor = "balanced";
+            tapping-term-ms = <280>;
+            quick-tap-ms = <175>;
+            require-prior-idle-ms = <150>;
+            bindings = <&kp>, <&kp>;
+            hold-trigger-key-positions = <0 1 2 3 4 10 11 12 13 14 15 22 23 24 25 26 27 34 35 36 37 38 39>;
+            hold-trigger-on-release;
+            hold-while-undecided;
+        };
     };
 
     keymap {
@@ -130,7 +193,7 @@
         default {
             bindings = <
 &kp Q      &kp W             &kp E                             &kp R  &kp T                                                                          &kp Y                                &kp U  &kp I        &kp O    &kp P
-&kp A      &kp S             &mt_exit_AML_on_tap LEFT_SHIFT D  &kp F  &kp G        &trans                &trans                                      &kp H                                &kp J  &kp K        &kp L    &kp MINUS
+&hml_2 LEFT_GUI A  &hml LEFT_ALT S  &hml LEFT_CONTROL D  &hml_2 LEFT_SHIFT F  &kp G        &trans                &trans                                      &kp H                                &hmr_2 RIGHT_SHIFT J  &hmr RIGHT_CONTROL K  &hmr RIGHT_ALT L  &hmr_2 RIGHT_GUI MINUS
 &kp Z      &kp X             &kp C                             &kp V  &kp B        &kp LEFT_GUI          &kp RIGHT_CONTROL                           &kp N                                &kp M  &lt 5 COMMA  &kp DOT  &kp BACKSPACE
 &kp LSHFT  &kp LEFT_CONTROL  &kp LEFT_ALT                      &mo 1  &lt 5 SPACE  &lt 2 LANGUAGE_2      &mt_exit_AML_on_tap RIGHT_SHIFT LANGUAGE_1  &mt_exit_AML_on_tap RIGHT_GUI ENTER                               &kp RIGHT_SHIFT
             >;


### PR DESCRIPTION
- hml/hmr: Ctrl・Alt用（balanced, 280ms, require-prior-idle 150ms）
- hml_2/hmr_2: Shift・Cmd用（+ hold-while-undecided でマウス操作に即反応）
- A=Cmd S=Alt D=Ctrl F=Shift / J=Shift K=Ctrl L=Alt -=Cmd
- Dキーの既存 mt_exit_AML_on_tap LEFT_SHIFT を hml LEFT_CONTROL に置き換え