### PR TITLE
feat: HRMの修飾キー順序をSCAGからGACSに変更

### DIFF
--- a/config/roBa.keymap
+++ b/config/roBa.keymap
@@ -130,7 +130,7 @@
         //   Row3: Z(22) X(23) C(24) V(25) B(26) m(27) | m(28) N(29) M(30) ,(31) .(32) BS(33)
         //   Row4: LS(34) LC(35) LA(36) mo1(37) spc(38) lang2(39) | lang1(40) ent(41) RS(42)
 
-        // Ctrl/Alt用（hold-while-undecided なし）- SCAG配置: S=Ctrl D=Alt
+        // Ctrl/Alt用（hold-while-undecided なし）- GACS配置: S=Alt D=Ctrl
         hml: home_row_mod_left {
             compatible = "zmk,behavior-hold-tap";
             label = "HML";
@@ -157,7 +157,7 @@
             hold-trigger-on-release;
         };
 
-        // Shift/GUI用（hold-while-undecided あり → マウス操作との組み合わせに即反応）- SCAG配置: A=Shift F=GUI
+        // Shift/GUI用（hold-while-undecided あり → マウス操作との組み合わせに即反応）- GACS配置: A=GUI F=Shift
         hml_2: home_row_mod_left_2 {
             compatible = "zmk,behavior-hold-tap";
             label = "HML_2";
@@ -193,7 +193,7 @@
         default {
             bindings = <
 &kp Q      &kp W             &kp E                             &kp R  &kp T                                                                          &kp Y                                &kp U  &kp I        &kp O    &kp P
-&hml_2 LEFT_SHIFT A  &hml LEFT_CONTROL S  &hml LEFT_ALT D  &hml_2 LEFT_GUI F  &kp G        &trans                &trans                                      &kp H                                &hmr_2 RIGHT_GUI J  &hmr RIGHT_ALT K  &hmr RIGHT_CONTROL L  &hmr_2 RIGHT_SHIFT MINUS
+&hml_2 LEFT_GUI A  &hml LEFT_ALT S  &hml LEFT_CONTROL D  &hml_2 LEFT_SHIFT F  &kp G        &trans                &trans                                      &kp H                                &hmr_2 RIGHT_SHIFT J  &hmr RIGHT_CONTROL K  &hmr RIGHT_ALT L  &hmr_2 RIGHT_GUI MINUS
 &kp Z      &kp X             &kp C                             &kp V  &kp B        &kp LEFT_GUI          &kp RIGHT_CONTROL                           &kp N                                &kp M  &lt 5 COMMA  &kp DOT  &kp BACKSPACE
 &kp LSHFT  &kp LEFT_CONTROL  &kp LEFT_ALT                      &mo 1  &lt 5 SPACE  &lt 2 LANGUAGE_2      &mt_exit_AML_on_tap RIGHT_SHIFT LANGUAGE_1  &mt_exit_AML_on_tap RIGHT_GUI ENTER                               &kp RIGHT_SHIFT
             >;


### PR DESCRIPTION
小指→人差し指の順をShift/Ctrl/Alt/GUIからGUI/Alt/Ctrl/Shiftに変更。 使用頻度に基づき、最多使用のShiftを強い人差し指側に配置。